### PR TITLE
Move face unlock flag from device's makefile to device.mk file

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -157,3 +157,6 @@ PRODUCT_COPY_FILES += \
 
 # Call the proprietary setup
 $(call inherit-product, vendor/google/seed/seed-vendor.mk)
+
+# Add face unlock - Thanks to @Tenshi2112 for flag!
+TARGET_SUPPORT_FACE_UNLOCK := true

--- a/lineage_seed.mk
+++ b/lineage_seed.mk
@@ -37,7 +37,3 @@ PRODUCT_BUILD_PROP_OVERRIDES += \
     PRIVATE_BUILD_DESC="seed_l8150-user 7.1.1 N0F27E 4103848 release-keys"
 
 BUILD_FINGERPRINT := google/seed/l8150:7.1.1/N0F27E/4103848:user/release-keys
-
-# Adds face unlock if package is available on ROM source
-# Thanks to @Tenshi2112 for telling about it
-TARGET_SUPPORT_FACE_UNLOCK := true


### PR DESCRIPTION
@TeGaX (@Tenshi2112 on Telegram) warned me regarding the location I added face unlock flag. Now, upon his instructions, I placed it correctly and it should work across all ROMs after this change.

This change will also be done for windowzytch/android_device_GM_GM9PRO_sprout and windowzytch/android_device_wileyfox_crackling.